### PR TITLE
Offlinestart

### DIFF
--- a/functions/DockerPython/DockerPython.py
+++ b/functions/DockerPython/DockerPython.py
@@ -180,9 +180,11 @@ def main():
     send_info({"message":"Lambda starting. Executing main..."})
     # NOTE: until support for local shadow service is added to the GGProvisioner,
     # this will not work offline
-    my_shadow = ggc_client.get_thing_shadow(thingName=THING_NAME)
-    desired_state = my_shadow['desired']
-    update_to_desired_state(desired_state)
+    my_shadow = json.loads(ggc_client.get_thing_shadow(thingName=THING_NAME)['payload'])
+    send_info({"my_shadow":my_shadow})
+    if 'desired' in my_shadow['state']:
+        desired_state = my_shadow['state']['desired']
+        update_to_desired_state(desired_state)
 
 # invoke main
 main()


### PR DESCRIPTION
*Description of changes:*
Lambda gets container state from shadow and runs containers upon lambda runtime start. This means that if you restart the device, the containers will be ran as soon as the runtime starts

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
